### PR TITLE
Fix: resource name to fix code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ node_modules
 segments_2i
 
 # Generated files
+nuget-local/*.nupkg
+nuget-local/*.snupkg
 **/Client/dist/*
 
 **/CMSModules/WebFarm/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,30 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": ".NET Core Launch (web)",
+      "name": ".NET Launch (DancingGoat)",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": ".NET: build (Solution)",
+      "program": "${workspaceFolder}/examples/DancingGoat/bin/Debug/net6.0/DancingGoat.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/examples/DancingGoat",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    },
+    {
+      "name": ".NET Launch (DancingGoat) - LOCAL_NUGET",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": ".NET: build (Solution) - LOCAL_NUGET",
       "program": "${workspaceFolder}/examples/DancingGoat/bin/Debug/net6.0/DancingGoat.dll",
       "args": [],
       "cwd": "${workspaceFolder}/examples/DancingGoat",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -57,6 +57,24 @@
       }
     },
     {
+      "label": ".NET: pack (TagManager)",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "pack",
+        "./src/Kentico.Xperience.TagManager",
+        "-c",
+        "Release",
+        "-o",
+        "nuget-local",
+        "-p:SIGN_FILE=false"
+      ],
+      "problemMatcher": "$msCompile",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      }
+    },
+    {
       "type": "npm",
       "script": "install",
       "path": "src/Kentico.Xperience.TagManager/Frontend",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,18 @@
       "problemMatcher": "$msCompile"
     },
     {
+      "label": ".NET: build (Solution) - LOCAL_NUGET",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "-p:LOCAL_NUGET=true",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
       "label": ".NET: rebuild (Solution)",
       "command": "dotnet",
       "type": "process",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,15 @@
     <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <!-- When NuGet supports this property, we can specify a * as the Kentico.Xperience.TagManager package version for local testing -->
+    <CentralPackageFloatingVersionsEnabled Condition="'$(LOCAL_NUGET)' == 'true'">true</CentralPackageFloatingVersionsEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Kentico.Xperience.Admin" Version="28.1.0" />
     <PackageVersion Include="Kentico.Xperience.WebApp" Version="28.1.0" />
     <PackageVersion Include="kentico.xperience.azurestorage" Version="28.1.0" />
     <PackageVersion Include="kentico.xperience.imageprocessing" Version="28.1.0" />
+    <PackageVersion Include="Kentico.Xperience.TagManager" Version="" Condition="'$(LOCAL_NUGET)' == 'true'" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.17.0.82934" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="NUnit" Version="4.0.1" />

--- a/docs/Contributing-Setup.md
+++ b/docs/Contributing-Setup.md
@@ -78,26 +78,33 @@ To run the Sample app Admin customization in development mode, add the following
 
 ### Test the package locally using the following commands
 
-1. Create a local packages folder
-
-   `mkdir ./test-packages`
-
-1. Add a local NuGet package config
-
-   `dotnet nuget add source ./test-packages`
-
-1. Generate a local package
-
-   `dotnet pack .\src\Kentico.Xperience.TagManager\ -c Release -o .\test-packages\ -p:SIGN_FILE=false`
+1. Generate a local package using the VS Code `.NET: pack (TagManager)` task or execute its command and arguments at the command line
+   This will generate a new `Kentico.Xperience.TagManager` package in the `nuget-local` folder with a version matching the version in your `Directory.Build.props`
 
 1. Use the NuGet package in the DancingGoat project instead of the project reference
 
-   1. Modify `examples\DancingGoat.csproj` replacing the `<ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" />` with `<PackageReference Include="Kentico.Xperience.TagManager" />`
-   1. Update the `Directory.Packages.props` with a reference to the `Kentico.Xperience.TagManager` package `<PackageVersion Include="Kentico.Xperience.TagManager" Verison="" />` with a version matching the value in the project's `Directory.Build.props`
+   1. Modify `examples\DancingGoat\DancingGoat.csproj` replacing the project reference with a package reference
 
-1. Run the `DancingGoat` application and ensure all functionality is correct.
+      ```xml
+      -<ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" />
+      +<PackageReference Include="Kentico.Xperience.TagManager" />
+      ```
 
-1. Ensure these changes are not committed to the repository
+   1. Update the `Directory.Packages.props` with a reference to the `Kentico.Xperience.TagManager` package
+
+      ```xml
+      +<PackageVersion Include="Kentico.Xperience.TagManager" Verison="" />
+      ```
+
+      Populate `Version=""` with the matching the value in the project's `Directory.Build.props`
+
+1. Rebuild the solution using the VS Code `.NET: rebuild (Solution)` task or run `dotnet build --no-incremental` at the command line
+
+1. Make sure the `Kentico.Xperience.TagManager.dll` version in the `examples\DancingGoat\bin\Debug\net6.0\` folder is the right version
+
+1. Run the `DancingGoat` application and ensure all functionality is correct
+
+1. Undo these changes to ensure they are not committed to the repository
 
 ### Create a PR
 

--- a/docs/Contributing-Setup.md
+++ b/docs/Contributing-Setup.md
@@ -81,30 +81,23 @@ To run the Sample app Admin customization in development mode, add the following
 1. Generate a local package using the VS Code `.NET: pack (TagManager)` task or execute its command and arguments at the command line
    This will generate a new `Kentico.Xperience.TagManager` package in the `nuget-local` folder with a version matching the version in your `Directory.Build.props`
 
-1. Use the NuGet package in the DancingGoat project instead of the project reference
+1. Update the `Directory.Packages.props` to populate the `Kentico.Xperience.TagManager` package `Version=""` with the matching the value from the project's `Directory.Build.props`
 
-   1. Modify `examples\DancingGoat\DancingGoat.csproj` replacing the project reference with a package reference
+   > In the future, we will be able to use floating versions to automatically select the highest (local) package version
 
-      ```xml
-      -<ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" />
-      +<PackageReference Include="Kentico.Xperience.TagManager" />
-      ```
+1. Build the solution with the `LOCAL_NUGET=true` property
 
-   1. Update the `Directory.Packages.props` with a reference to the `Kentico.Xperience.TagManager` package
-
-      ```xml
-      +<PackageVersion Include="Kentico.Xperience.TagManager" Verison="" />
-      ```
-
-      Populate `Version=""` with the matching the value in the project's `Directory.Build.props`
-
-1. Rebuild the solution using the VS Code `.NET: rebuild (Solution)` task or run `dotnet build --no-incremental` at the command line
+   > You can use the VS Code `.NET: build (Solution) - LOCAL_NUGET` task
 
 1. Make sure the `Kentico.Xperience.TagManager.dll` version in the `examples\DancingGoat\bin\Debug\net6.0\` folder is the right version
 
 1. Run the `DancingGoat` application and ensure all functionality is correct
 
-1. Undo these changes to ensure they are not committed to the repository
+   > You can use the `.NET Launch (DancingGoat) - LOCAL_NUGET` lauch setting in VS Code
+
+1. Undo the `Directory.Packages.props` version number change to ensure it is not committed to the repository
+
+1. Perform a normal build to reset any modified `packages.lock.json` files
 
 ### Create a PR
 

--- a/docs/Contributing-Setup.md
+++ b/docs/Contributing-Setup.md
@@ -62,6 +62,8 @@ To run the Sample app Admin customization in development mode, add the following
 
 ## Development Workflow
 
+### Prepare your Git branch and commits
+
 1. Create a new branch with one of the following prefixes
 
    - `feat/` - for new functionality
@@ -74,8 +76,33 @@ To run the Sample app Admin customization in development mode, add the following
 
 1. Commit changes, with a commit message preferably following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) convention.
 
-1. Once ready, create a PR on GitHub. The PR will need to have all comments resolved and all tests passing before it will be merged.
+### Test the package locally using the following commands
 
-   - The PR should have a helpful description of the scope of changes being contributed.
-   - Include screenshots or video to reflect UX or UI updates
-   - Indicate if new settings need to be applied when the changes are merged - locally or in other environments
+1. Create a local packages folder
+
+   `mkdir ./test-packages`
+
+1. Add a local NuGet package config
+
+   `dotnet nuget add source ./test-packages`
+
+1. Generate a local package
+
+   `dotnet pack .\src\Kentico.Xperience.TagManager\ -c Release -o .\test-packages\ -p:SIGN_FILE=false`
+
+1. Use the NuGet package in the DancingGoat project instead of the project reference
+
+   1. Modify `examples\DancingGoat.csproj` replacing the `<ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" />` with `<PackageReference Include="Kentico.Xperience.TagManager" />`
+   1. Update the `Directory.Packages.props` with a reference to the `Kentico.Xperience.TagManager` package `<PackageVersion Include="Kentico.Xperience.TagManager" Verison="" />` with a version matching the value in the project's `Directory.Build.props`
+
+1. Run the `DancingGoat` application and ensure all functionality is correct.
+
+1. Ensure these changes are not committed to the repository
+
+### Create a PR
+
+Once ready, create a PR on GitHub. The PR will need to have all comments resolved and all tests passing before it will be merged.
+
+- The PR should have a helpful description of the scope of changes being contributed.
+- Include screenshots or video to reflect UX or UI updates
+- Indicate if new settings need to be applied when the changes are merged - locally or in other environments

--- a/examples/DancingGoat/DancingGoat.csproj
+++ b/examples/DancingGoat/DancingGoat.csproj
@@ -22,13 +22,14 @@
     <DefineConstants>$(DefineConstants);SEPARATED_ADMIN</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" />
+    <ProjectReference Include="..\..\src\Kentico.Xperience.TagManager\Kentico.Xperience.TagManager.csproj" Condition="'$(LOCAL_NUGET)' != 'true'" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="kentico.xperience.admin" Condition="'$(SeparatedAdmin)' == 'false'" />
     <PackageReference Include="kentico.xperience.azurestorage" />
     <PackageReference Include="kentico.xperience.imageprocessing" />
     <PackageReference Include="kentico.xperience.webapp" />
+    <PackageReference Include="Kentico.Xperience.TagManager" Condition="'$(LOCAL_NUGET)' == 'true'" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -10,7 +10,7 @@
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
     <packageSource key="LocalPackages">
       <!-- Uncomment to test local versions of the NuGet package -->
-      <!-- <package pattern="Kentico.Xperience.TagManager" /> -->
+      <package pattern="Kentico.Xperience.TagManager" />
     </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,12 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+    <add key="LocalPackages" value="./nuget-local" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="LocalPackages">
+      <!-- Uncomment to test local versions of the NuGet package -->
+      <!-- <package pattern="Kentico.Xperience.TagManager" /> -->
+    </packageSource>
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>

--- a/src/Kentico.Xperience.TagManager/Admin/TagManagerConstants.cs
+++ b/src/Kentico.Xperience.TagManager/Admin/TagManagerConstants.cs
@@ -9,9 +9,8 @@ internal static class TagManagerConstants
 
     internal static class ResourceConstants
     {
-        private const string ResourceNamePrefix = "Kentico.Xperience.TagManager";
-        public const string ResourceDisplayName = "Kentico Tag Manager";
-        public const string ResourceName = ResourceNamePrefix;
+        public const string ResourceDisplayName = "Kentico Integration - Tag Manager";
+        public const string ResourceName = "CMS.Integration.TagManager";
         public const string ResourceDescription = "Kentico Tag Manager custom data";
         public const bool ResourceIsInDevelopment = false;
     }

--- a/src/Kentico.Xperience.TagManager/Admin/TagManagerModuleInstaller.cs
+++ b/src/Kentico.Xperience.TagManager/Admin/TagManagerModuleInstaller.cs
@@ -27,7 +27,10 @@ internal class TagManagerModuleInstaller : ITagManagerModuleInstaller
 
     private ResourceInfo InstallModule()
     {
-        var resourceInfo = resourceInfoProvider.Get(ResourceConstants.ResourceName) ?? new ResourceInfo();
+        var resourceInfo = resourceInfoProvider.Get(ResourceConstants.ResourceName)
+            // Handle v1.0.0 resource name
+            ?? resourceInfoProvider.Get("Kentico.Xperience.TagManager")
+            ?? new ResourceInfo();
 
         resourceInfo.ResourceDisplayName = ResourceConstants.ResourceDisplayName;
         resourceInfo.ResourceName = ResourceConstants.ResourceName;


### PR DESCRIPTION
# Motivation

- Prefix the `ResourceInfo.ResourceName` created for custom data types with `CMS` to prevent the library's data types from appearing in generated code
- Adds project configuration and documentation to easily enable local testing of the library as a NuGet package

## Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [X] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

- Run `dotnet run -- --kxp-codegen --type "Classes"` in the example `DancingGoat` project and verify no custom data types C# classes are created from the `Kentico.Xperience.TagManager` project
