### PR TITLE
Fix: CI Support

### DIFF
--- a/src/Kentico.Xperience.TagManager/Admin/TagManagerModuleInstaller.cs
+++ b/src/Kentico.Xperience.TagManager/Admin/TagManagerModuleInstaller.cs
@@ -48,14 +48,14 @@ internal class TagManagerModuleInstaller : ITagManagerModuleInstaller
 
     private static void InstallChannelCodeSnippetClass(ResourceInfo resourceInfo)
     {
-        var channelCodeSnippetClass = DataClassInfoProvider.GetDataClassInfo(ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName) ??
+        var info = DataClassInfoProvider.GetDataClassInfo(ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName) ??
                                       DataClassInfo.New(ChannelCodeSnippetInfo.OBJECT_TYPE);
 
-        channelCodeSnippetClass.ClassName = ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName;
-        channelCodeSnippetClass.ClassTableName = ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName.Replace(".", "_");
-        channelCodeSnippetClass.ClassDisplayName = "Channel Code Snippet";
-        channelCodeSnippetClass.ClassResourceID = resourceInfo.ResourceID;
-        channelCodeSnippetClass.ClassType = ClassType.OTHER;
+        info.ClassName = ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName;
+        info.ClassTableName = ChannelCodeSnippetInfo.TYPEINFO.ObjectClassName.Replace(".", "_");
+        info.ClassDisplayName = "Channel Code Snippet";
+        info.ClassResourceID = resourceInfo.ResourceID;
+        info.ClassType = ClassType.OTHER;
         var formInfo = FormHelper.GetBasicFormDefinition(nameof(ChannelCodeSnippetInfo.ChannelCodeSnippetID));
         var formItem = new FormFieldInfo
         {
@@ -165,8 +165,30 @@ internal class TagManagerModuleInstaller : ITagManagerModuleInstaller
         };
         formInfo.AddFormItem(formItem);
 
-        channelCodeSnippetClass.ClassFormDefinition = formInfo.GetXmlDefinition();
+        SetFormDefinition(info, formInfo);
 
-        DataClassInfoProvider.SetDataClassInfo(channelCodeSnippetClass);
+        if (info.HasChanged)
+        {
+            DataClassInfoProvider.SetDataClassInfo(info);
+        }
+    }
+
+    /// <summary>
+    /// Ensure that the form is not upserted with any existing form
+    /// </summary>
+    /// <param name="info"></param>
+    /// <param name="form"></param>
+    private static void SetFormDefinition(DataClassInfo info, FormInfo form)
+    {
+        if (info.ClassID > 0)
+        {
+            var existingForm = new FormInfo(info.ClassFormDefinition);
+            existingForm.CombineWithForm(form, new());
+            info.ClassFormDefinition = existingForm.GetXmlDefinition();
+        }
+        else
+        {
+            info.ClassFormDefinition = form.GetXmlDefinition();
+        }
     }
 }


### PR DESCRIPTION
# Motivation

- Fixes issue where CI files for the library's custom data types were regenerated with every application restart. This didn't break any functionality but created noise in the CI repository and could lead to more Git conflicts

## Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

Enable CI in the example app and start the application twice. The TagManger CI files should not change.
