### PR TITLE
Fix: NuGet static assets

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -122,6 +122,41 @@
       "detail": "webpack serve --mode development"
     },
     {
+      "type": "npm",
+      "script": "install",
+      "path": "src/Kentico.Xperience.TagManager/Admin/Client",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: install - src/Kentico.Xperience.TagManager/Admin/Client",
+      "detail": "install dependencies from package"
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "path": "src/Kentico.Xperience.TagManager/Admin/Client",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: build - src/Kentico.Xperience.TagManager/Admin/Client",
+      "detail": "webpack --mode=production"
+    },
+    {
+      "type": "npm",
+      "script": "build:dev",
+      "path": "src/Kentico.Xperience.TagManager/Admin/Client",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: build:dev - src/Kentico.Xperience.TagManager/Admin/Client",
+      "detail": "webpack --mode=development"
+    },
+    {
+      "type": "npm",
+      "script": "start",
+      "path": "src/Kentico.Xperience.TagManager/Admin/Client",
+      "problemMatcher": [],
+      "label": "npm: start - src/Kentico.Xperience.TagManager/Admin/Client",
+      "detail": "webpack serve --mode development"
+    },
+    {
       "label": "dotnet: watch (DancingGoat)",
       "command": "dotnet",
       "type": "process",

--- a/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package.json
+++ b/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Xperience by Kentico Tag manager",
   "scripts": {
+    "start": "npm run watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode=production --node-env=production",
     "build:dev": "webpack --mode=development",

--- a/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
+++ b/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
@@ -6,7 +6,7 @@
 		<Description>Enables marketers to author custom tags that can be embedded in a website channel. Example: GA4, cookie banners, custom CSS.</Description>
 		<RepositoryUrl>https://github.com/kentico/xperience-by-kentico-tag-manager</RepositoryUrl>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<AdminOrgName>kentico</AdminOrgName>
 		<RootNamespace>Kentico.Xperience.TagManager</RootNamespace>
@@ -58,10 +58,4 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Admin\Client\dist\" />
-	  <Folder Include="wwwroot\js\" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
# Motivation

Fixes #23 by removing incorrect `<Folder>` items in the `.csproj`
Also adds VS Code tasks for building the `Frontend` JS

## Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

1. Update the `Directory.Build.props` `VersionPrefix` to `3.0.1`
2. Set the version of `Kentico.Xperience.TagManager` in `Directory.Packages.props` to `3.0.1`
3. Uncomment the `LocalPackages` package pattern for `Kentico.Xperience.TagManager` in the `nuget.config`
4. Run the `.NET pack` VS Code task to create a local NuGet package
5. Run the `.NET Launch (DancingGoat) - LOCAL_NUGET` launch configuration to load the library from the local NuGet package
6. See the `ktc-tagmanager.js` script loads correctly

> Note: These steps are also [outlined in the docs](https://github.com/Kentico/xperience-by-kentico-tag-manager/blob/v3.0.0/docs/Contributing-Setup.md#test-the-package-locally-using-the-following-commands).
