### PR TITLE
Fix application referencing nonexistent file ktc-tagmanager.js

### DIFF
--- a/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
+++ b/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
@@ -45,7 +45,7 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="NpmInstallHelpScript" BeforeTargets="NpmBuildClient" Condition=" '$(Configuration)|$(Platform)' != 'Debug|AnyCPU' ">
+	<Target Name="NpmInstallHelpScript" BeforeTargets="NpmBuildHelpScript" Condition=" '$(Configuration)|$(Platform)' != 'Debug|AnyCPU' ">
 		<Exec Command="npm ci --no-audit --no-fund" WorkingDirectory="$(MSBuildProjectDirectory)\Admin\FrontEnd" />
 	</Target>
 	<Target Name="NpmBuildHelpScript" BeforeTargets="BeforeBuild" Condition=" '$(Configuration)|$(Platform)' != 'Debug|AnyCPU' ">


### PR DESCRIPTION
BeforeTargets of NpmInstallHelpScript changed to correct target

# Motivation

Fix issue: Application is referencing nonexistent file ktc-tagmanager.js #30
https://github.com/Kentico/xperience-by-kentico-tag-manager/issues/30