### PR TITLE
Rename client packages

### DIFF
--- a/src/Kentico.Xperience.TagManager/Admin/Client/package-lock.json
+++ b/src/Kentico.Xperience.TagManager/Admin/Client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "xperience-tagmanager-web-admin",
+  "name": "@kentico/xperience-tag-manager-web-admin",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "xperience-tagmanager-web-admin",
+      "name": "@kentico/xperience-tag-manager-web-admin",
       "version": "1.0.0",
       "dependencies": {
         "@kentico/xperience-admin-base": "28.3.1",

--- a/src/Kentico.Xperience.TagManager/Admin/Client/package.json
+++ b/src/Kentico.Xperience.TagManager/Admin/Client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xperience-tagmanager-web-admin",
+  "name": "@kentico/xperience-tag-manager-web-admin",
   "version": "1.0.0",
   "description": "Xperience by Kentico Tag manager",
   "private": true,

--- a/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package-lock.json
+++ b/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ktc-tagmanager",
+  "name": "@kentico/xperience-tag-manager",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ktc-tagmanager",
+      "name": "@kentico/xperience-tag-manager",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package.json
+++ b/src/Kentico.Xperience.TagManager/Admin/FrontEnd/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ktc-tagmanager",
+  "name": "@kentico/xperience-tag-manager",
   "version": "1.0.0",
   "description": "Xperience by Kentico Tag manager",
   "scripts": {

--- a/src/Kentico.Xperience.TagManager/Admin/FrontEnd/webpack.config.js
+++ b/src/Kentico.Xperience.TagManager/Admin/FrontEnd/webpack.config.js
@@ -7,7 +7,7 @@ const config = {
     entry: "./src/index.js",
     output: {
         path: path.resolve(__dirname, "../.././wwwroot/js"),
-        filename: "ktc-tagmanager.js",
+        filename: "@kentico/xperience-tag-manager.js",
         module: true,
     },
     experiments: {

--- a/src/Kentico.Xperience.TagManager/Admin/FrontEnd/webpack.config.js
+++ b/src/Kentico.Xperience.TagManager/Admin/FrontEnd/webpack.config.js
@@ -7,7 +7,7 @@ const config = {
     entry: "./src/index.js",
     output: {
         path: path.resolve(__dirname, "../.././wwwroot/js"),
-        filename: "@kentico/xperience-tag-manager.js",
+        filename: "xperience-tag-manager.js",
         module: true,
     },
     experiments: {

--- a/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
+++ b/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
@@ -58,4 +58,8 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="wwwroot\js\" />
+	</ItemGroup>
 </Project>

--- a/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
+++ b/src/Kentico.Xperience.TagManager/Kentico.Xperience.TagManager.csproj
@@ -58,8 +58,4 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="wwwroot\js\" />
-	</ItemGroup>
 </Project>

--- a/src/Kentico.Xperience.TagManager/Rendering/CodeSnippetTagHelperComponent.cs
+++ b/src/Kentico.Xperience.TagManager/Rendering/CodeSnippetTagHelperComponent.cs
@@ -151,7 +151,7 @@ internal class CodeSnippetTagHelperComponent : TagHelperComponent
                 ["type"] = "module",
                 ["src"] = fileVersionProvider.AddFileVersionToPath(
                     ViewContext.HttpContext.Request.PathBase,
-                    urlHelper.Content("~/_content/Kentico.Xperience.TagManager/js/@kentico/xperience-tag-manager.js"))
+                    urlHelper.Content("~/_content/Kentico.Xperience.TagManager/js/xperience-tag-manager.js"))
             }
         };
 

--- a/src/Kentico.Xperience.TagManager/Rendering/CodeSnippetTagHelperComponent.cs
+++ b/src/Kentico.Xperience.TagManager/Rendering/CodeSnippetTagHelperComponent.cs
@@ -151,7 +151,7 @@ internal class CodeSnippetTagHelperComponent : TagHelperComponent
                 ["type"] = "module",
                 ["src"] = fileVersionProvider.AddFileVersionToPath(
                     ViewContext.HttpContext.Request.PathBase,
-                    urlHelper.Content("~/_content/Kentico.Xperience.TagManager/js/ktc-tagmanager.js"))
+                    urlHelper.Content("~/_content/Kentico.Xperience.TagManager/js/@kentico/xperience-tag-manager.js"))
             }
         };
 


### PR DESCRIPTION
# Motivation

Renames
ktc-tagmanager to @kentico/xperience-tag-manager
xperience-tagmanager-web-admin to @kentico/xperience-tag-manager-web-admin
to address possible package resolution issues.