### PR TITLE
fix(TagManager): Display in Administration in preview and pagebuilder

### DIFF
--- a/src/Kentico.Xperience.TagManager/Admin/CodeSnippetExtensions.cs
+++ b/src/Kentico.Xperience.TagManager/Admin/CodeSnippetExtensions.cs
@@ -12,5 +12,5 @@ internal static class CodeSnippetExtensions
     public const string DisplayModeFormComponentOptions = $"{nameof(CodeSnippetAdministrationDisplayMode.None)};Do not display in Administration\r\n" +
                                                 $"{nameof(CodeSnippetAdministrationDisplayMode.PreviewOnly)};Display in the Preview view mode only\r\n" +
                                                 $"{nameof(CodeSnippetAdministrationDisplayMode.PageBuilderOnly)};Display in the Page Builder only\r\n" +
-                                                $"{nameof(CodeSnippetAdministrationDisplayMode.Both)}Display in the Preview view mode and the Page Builder";
+                                                $"{nameof(CodeSnippetAdministrationDisplayMode.Both)};Display in the Preview view mode and the Page Builder";
 }


### PR DESCRIPTION
# Motivation

* Fixes the following issue
* TagManager - Tag is not rendered on PageBuilder nor Preview (https://github.com/orgs/Kentico/projects/15/views/1?pane=issue&itemId=72066332)