### PR TITLE
Document content type filtering feature from PR #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ dotnet add package Kentico.Xperience.TagManager
        - Bottom of the body - inserts a script right before the closing body tag.
    - Select tag location within the rendered page HTML
    - Fill in a consent if required.
+   - (Optional) Select specific content types to restrict tag rendering to only those page types. If no content types are selected, the tag will render on all pages.
    - Check 'Enable tag rendering' to activate the tag or uncheck to deactivate
    - Select whether you want to display tags in the Xperience administration preview or Page Builder, or both. This option defaults to None.
 5. During rendering the livesite page, the Tag manager module automatically adds custom code snippets with accepted consents to defined locations.
@@ -119,6 +120,7 @@ If you use the [Continuous Deployment](https://docs.kentico.com/x/YgaiCQ) featur
 
 * `kenticotagmanager.channelcodesnippet`
 * `kenticotagmanager.channelcodesnippetitem`
+* `kenticotagmanager.channelcodesnippetitemcontenttype`
 
 Running the CD restore (with `<RestoreMode>` set to `Full`) removes any Tag Manager scripts that exist on the target instance, but are not included in the CD data. 
 
@@ -128,6 +130,7 @@ You can prevent this issue by adding excluded object types to your *repository.c
 <ExcludedObjectTypes>
     <ObjectType>kenticotagmanager.channelcodesnippet</ObjectType>
     <ObjectType>kenticotagmanager.channelcodesnippetitem</ObjectType>
+    <ObjectType>kenticotagmanager.channelcodesnippetitemcontenttype</ObjectType>
 </ExcludedObjectTypes>
 ```
 


### PR DESCRIPTION
Adds documentation for the content type filtering feature introduced in PR #85, which allows restricting tag rendering to specific page content types.

## Changes

- **Quick Start**: Added step documenting the optional content type selector. When no types are selected, tags render on all pages (backward compatible).

- **Continuous Deployment**: Added `kenticotagmanager.channelcodesnippetitemcontenttype` binding object type to the list and example XML configuration.

## Example Configuration

```xml
<ExcludedObjectTypes>
    <ObjectType>kenticotagmanager.channelcodesnippet</ObjectType>
    <ObjectType>kenticotagmanager.channelcodesnippetitem</ObjectType>
    <ObjectType>kenticotagmanager.channelcodesnippetitemcontenttype</ObjectType>
</ExcludedObjectTypes>
```

Closes #89

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> I want to update the documentation for the work that was done in https://github.com/Kentico/xperience-by-kentico-tag-manager/pull/85 I logged an issue to update the documentation you can read here https://github.com/Kentico/xperience-by-kentico-tag-manager/issues/89 do you think you can create a new branch in my fork, update the documentation (README.md) and then commit and PR


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.