### PR TITLE
Bump to v5.0.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 


### PR DESCRIPTION
This pull request updates the `CodeSnippetTagHelperComponent` to improve how it determines the website channel and page content type before rendering code snippets. The changes ensure that code snippets are only processed when a valid website channel is present, and refactor how the content type ID is retrieved. Additionally, the project version is incremented.

### Rendering logic improvements

* Added a dependency on `IWebsiteChannelContext` to `CodeSnippetTagHelperComponent` and updated its constructor to require this parameter. [[1]](diffhunk://#diff-cfbace35bf5b1767235b8166373e7eee696702e1c6c8e0105da4119c95b1d858R3) [[2]](diffhunk://#diff-cfbace35bf5b1767235b8166373e7eee696702e1c6c8e0105da4119c95b1d858R30-R45)
* Changed the code snippet processing logic to check for a valid website channel using `websiteChannelContext.WebsiteChannelID` before attempting to retrieve the web page data context and content type ID. This prevents unnecessary processing when the channel is invalid.
* Refactored content type ID retrieval to only occur if the web page data context is successfully retrieved, improving reliability and clarity.

### Version update

* Bumped the project version prefix from `5.0.1` to `5.0.2` in `Directory.Build.props`.
