### PR TITLE
Bump to v6.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ Xperience by Kentico Tag Manager is a .NET 8 class library that integrates with 
 ### Package Testing - TIMING VERIFIED
 To test local package changes:
 1. `dotnet pack ./src/Kentico.Xperience.TagManager -c Release -o nuget-local -p:SIGN_FILE=false` -- takes ~22 seconds, creates local NuGet package
-2. Update `Directory.Packages.props`: Set `Kentico.Xperience.TagManager` version to match the version in `Directory.Build.props` (currently 4.2.2)
+2. Update `Directory.Packages.props`: Set `Kentico.Xperience.TagManager` version to match the version in `Directory.Build.props`
 3. Update `nuget.config`: Uncomment `<package pattern="Kentico.Xperience.TagManager" />` in LocalPackages section
 4. `dotnet build -p:LOCAL_NUGET=true` -- takes ~7 seconds, builds solution using local package
 5. Verify DLL version in `examples/DancingGoat/bin/Debug/net8.0/` matches expected version
@@ -98,7 +98,7 @@ For admin UI development, add to DancingGoat User Secrets:
 
 ### Key Files
 - `global.json` - Specifies exact .NET SDK version requirement (8.0.411)
-- `Directory.Build.props` - Contains version (4.2.2) and package metadata
+- `Directory.Build.props` - Contains version and package metadata
 - `Directory.Packages.props` - Central package version management
 - `nuget.config` - Local package testing configuration
 - `.github/workflows/ci.yml` - Build and test automation
@@ -146,7 +146,7 @@ dotnet build --configuration Release --no-restore
 # Test local package
 dotnet pack ./src/Kentico.Xperience.TagManager -c Release -o nuget-local -p:SIGN_FILE=false
 
-# Update Directory.Packages.props version to 4.2.2
+# Update Directory.Packages.props version to latest version
 # Uncomment package pattern in nuget.config
 dotnet build -p:LOCAL_NUGET=true
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <VersionSuffix>prerelease-1</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <PackageProjectUrl>https://github.com/Kentico/xperience-by-kentico-tag-manager</PackageProjectUrl>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Tag Manager integration enabling marketers to include prebuilt and custom tags i
 
 | Xperience Version | Library Version |
 | ----------------- | --------------- |
+| >= 31.0.0         | >= 6.0.0        |
 | >= 30.6.0         | >= 4.2.0        |
 | >= 30.5.1         | >= 4.1.0        |
 | >= 30.0.0         | >= 4.0.0        |


### PR DESCRIPTION
This pull request makes minor updates to versioning information for the project. The most important changes are:

Versioning and release updates:

* Removed the `VersionSuffix` value from `Directory.Build.props`, indicating the project is no longer marked as a prerelease.
* Updated the compatibility table in `README.md` to include support for Xperience version 31.0.0 and library version 6.0.0.Removed the version suffix from the project properties.